### PR TITLE
Use debug logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 ._*
 npm-debug.log
 node_modules
+
+# lockfiles
+yarn.lock
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ $ yarn || yarn install || npm install
 ```
 $ yarn test || npm test
 ```
+
+## Debug
+
+This lib uses the [debug](https://www.npmjs.com/package/debug) module to log all internal errors and info. To enable this on debug needings set the DEBUG environment variable:
+
+```
+$ DEBUG=measuresjs:*
+```

--- a/lib/measures.js
+++ b/lib/measures.js
@@ -1,7 +1,9 @@
 var dgram = require('dgram');
 var async = require('async');
+var info = require('debug')('measuresjs:info');
+var error = require('debug')('measuresjs:error');
 
-function Measure(client, address, debug) {
+function Measure(client, address) {
   if (!client) throw new Error('Measures class: client could not be empty.');
   if (typeof(client) !== 'string') throw new Error('Measures class: client must be a string.');
   if (typeof(address) !== 'object') throw new Error('Measures class: address must be an object.');
@@ -23,7 +25,7 @@ function Measure(client, address, debug) {
   }, 2);
 
   q.drain = function () {
-    if (debug) console.log('[measuresjs-debug]', 'all messages have been sent.');
+    info('all messages have been sent.');
   };
 
   this.metrify = function (metric, counter, dms, cb) {
@@ -36,8 +38,6 @@ function Measure(client, address, debug) {
       count: counter || 1
     };
 
-    var dimensions = dms || {};
-
     Object.keys(message).forEach(function (prop) {
       dms[prop] = message[prop];
     });
@@ -45,9 +45,7 @@ function Measure(client, address, debug) {
     var buffer = new Buffer(JSON.stringify(dms));
 
     q.push({buffer: buffer, callback: cb}, function (err) {
-      if (debug) {
-        (err) ? console.log(err) : console.log('[measuresjs-debug]', 'metrics sent.');
-      }
+      (err) ? error(err) : info('metrics sent.');
     });
   };
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "author": "Jonatas Pedraza <jonatas.pedraza@corp.globo.com>",
   "license": "MIT License",
-  
   "dependencies": {
     "async": "^1.4.0",
     "debug": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "measuresjs",
   "version": "1.2.0",
+  "engines": {
+    "node": ">=6.0"
+  },
   "description": "a nodejs module to send metrics to measures services",
   "main": "index.js",
   "scripts": {
@@ -17,8 +20,10 @@
   ],
   "author": "Jonatas Pedraza <jonatas.pedraza@corp.globo.com>",
   "license": "MIT License",
+  
   "dependencies": {
-    "async": "^1.4.0"
+    "async": "^1.4.0",
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
This PR aims to remove the needing to pass a debug option to imperatively enable internal logs. Instead, it will be possible to set an environment variable up using the pattern proposed by the [debug](https://www.npmjs.com/package/debug) module.