### PR TITLE
Use Buffer factory instead of the constructor

### DIFF
--- a/lib/measures.js
+++ b/lib/measures.js
@@ -42,7 +42,7 @@ function Measure(client, address) {
       dms[prop] = message[prop];
     });
 
-    var buffer = new Buffer(JSON.stringify(dms));
+    var buffer = Buffer.from(JSON.stringify(dms));
 
     q.push({buffer: buffer, callback: cb}, function (err) {
       (err) ? error(err) : info('metrics sent.');


### PR DESCRIPTION
The Buffer constructor was deprecated since the node v.6.0.0 [More info](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding)