### PR TITLE
Aceitar valor `0` no parâmetro `counter`

### DIFF
--- a/lib/measures.js
+++ b/lib/measures.js
@@ -35,7 +35,7 @@ function Measure(client, address) {
     var message = {
       client: client,
       metric: metric,
-      count: counter || 1
+      count: typeof(counter) === "number" ? counter : 1
     };
 
     Object.keys(message).forEach(function (prop) {


### PR DESCRIPTION
Quando o `counter` é `0` o servidor recebe `1`, isso vai corrigir esse problema.