### PR TITLE
Connection error handler

### DIFF
--- a/lib/measures.js
+++ b/lib/measures.js
@@ -13,19 +13,26 @@ function Measure(client, address) {
   if (typeof(address.port) !== 'number') throw new Error('Measures class: address.port must be an integer.');
 
   var q = async.queue(function (task, cb) {
-    var socket = dgram.createSocket('udp4');
-    socket.send(task.buffer, 0, task.buffer.length,
-      address.port, address.host,
-      function (err) {
-        socket.close();
+    let socket = dgram.createSocket('udp4');
+
+    socket.connect(address.port, address.host, function(err) {
+      if (err) {
         if (task.callback) task.callback(err);
-        cb();
+        cb(err);
+      } else {
+        socket.send(task.buffer,
+          function (err) {
+            socket.close();
+            if (task.callback) task.callback(err);
+            cb(err);
+          }
+        );
       }
-    );
+    });
   }, 2);
 
   q.drain = function () {
-    info('all messages have been sent.');
+    info('all messages have been processed.');
   };
 
   this.metrify = function (metric, counter, dms, cb) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "measuresjs",
   "version": "1.2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=12.0"
   },
   "description": "a nodejs module to send metrics to measures services",
   "main": "index.js",
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^2.2.5",
-    "mock-udp": "^0.1.1"
+    "mocha": "^2.2.5"
   }
 }

--- a/test/mock-udp/index.js
+++ b/test/mock-udp/index.js
@@ -1,0 +1,92 @@
+var Socket = require('dgram').Socket;
+
+function Scope() {
+    this._done = false;
+    this.buffer = null;
+    this.offset = 0;
+    this.length = 0;
+    this.port = 0;
+    this.address = null;
+}
+Scope.prototype.done = function() {
+    if (!this._done)
+        throw new Error('Scope was not used!');
+    return true;
+}
+
+function overriddenSocketSend(buffer, offset, length, port, address, callback) {
+    if (offset >= buffer.length)
+        throw new Error('Offset into buffer too large');
+
+    if (offset + length > buffer.length)
+        throw new Error('Offset + length beyond buffer length');
+
+    var newBuffer = buffer.slice(offset, offset + length);
+
+    var host = address + ':' + port;
+    if (intercepts.hasOwnProperty(host)) {
+        intercepts[host].forEach(function(scope){
+            // Populate scope with data what was sent
+            scope._done = true;
+            scope.buffer = newBuffer;
+            scope.offset = offset;
+            scope.length = length;
+            scope.port = port;
+            scope.address = address;
+        });
+        // scopes have been used, clean up so they don't run again
+        delete intercepts[host];
+
+        if (callback)
+            callback(null, length);
+        return;
+    }
+    throw new Error('Request sent to unmocked path: ' + host);
+}
+overriddenSocketSend._mocked = true;
+
+
+function overriddenSocketConnect(port, address = '127.0.0.1', cb = () => {}) {
+  this.send = (buffer, callback) => {
+    return overriddenSocketSend(buffer, null, null, port, address, callback)
+  }
+  cb()
+}
+overriddenSocketConnect._mocked = true;
+
+
+var intercepts = {};
+function add(path) {
+    if (!intercepts.hasOwnProperty(path)) {
+        intercepts[path] = [];
+    }
+    var scope = new Scope();
+    intercepts[path].push(scope);
+    return scope;
+}
+
+function cleanInterceptions() {
+    intercepts = {};
+}
+
+var oldSocketSend = Socket.prototype.send;
+var oldSocketConnect = Socket.prototype.connect;
+function restoreSocketPrototype() {
+    Socket.prototype.send = oldSocketSend;
+    Socket.prototype.connect = oldSocketConnect
+}
+
+// Punch Socket prototype in the mouth
+function interceptSocketPrototype() {
+    Socket.prototype.send = overriddenSocketSend;
+    Socket.prototype.connect = overriddenSocketConnect;
+}
+interceptSocketPrototype();
+
+module.exports = add;
+module.exports.revert = restoreSocketPrototype;
+module.exports.intercept = interceptSocketPrototype;
+module.exports.clean = cleanInterceptions;
+module.exports.isMocked = function() { 
+  return Socket.prototype.send.hasOwnProperty('_mocked') && Socket.prototype.connect.hasOwnProperty('_mocked')
+}

--- a/test/packets.test.js
+++ b/test/packets.test.js
@@ -1,12 +1,11 @@
-var dgram = require('dgram');
 var expect = require('chai').expect;
-var mockudp = require('mock-udp');
+var mockudp = require('./mock-udp');
 var Measures = require('..');
 
 describe('Packets', function () {
   describe('#send one packet', function () {
     it('should send one packet', function (done) {
-      var scope = mockudp('localhost:1984');
+      mockudp('localhost:1984');
       var measures = new Measures('myclient', {host: 'localhost', port: 1984});
       var doc = {name: 'jon', lastname: 'doe', age: 22};
 


### PR DESCRIPTION
Este PR tem como intuito melhorar a tratativa nos casos em que há alguma falha de conexão.

Devido a mudança na implementação, o mock utilizado nos testes parou de funcionar. Tentamos abrir um PR na lib `mock-udp`, mas até o momento o dono não se manifestou, então adicionamos a nova implementação do mock dentro do projeto como um arquivo.